### PR TITLE
fix: bad config type path on Windows

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -139,7 +139,8 @@ export const initConfig = async () => {
       break
     case 'TypeScript': {
       filePath += '.ts'
-      contents = `import type { Config } from '${await findConfigTypePath()}'
+      const configTypePath = (await findConfigTypePath()).replace(/\\/g, '/')
+      contents = `import type { Config } from '${configTypePath}'
 
 const config: Config = ${JSON.stringify(demoConfig, undefined, 2)}
 


### PR DESCRIPTION
### Description

On Windows, `findConfigTypePath()` returns a Windows-style path (use `'\\'` as directory separator), which is used as-is in TypeScript demo config file.

This results in importing config type from a bad path on Windows:

![bad-path](https://user-images.githubusercontent.com/86521894/195980109-36c85618-10d5-4b49-9eaf-a963aab9e6ed.png)

This PR fixes this bug by replacing config type path's all `'\\'` with `'/'` when initializing TypeScript demo config file.

### Linked Issues


### Additional context

